### PR TITLE
Allows step-wrapped functions to be used outside of a running test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build
 /.tox
 /pytest_allure_adaptor.egg-info
 /.coverage
+.cache

--- a/allure/pytest_plugin.py
+++ b/allure/pytest_plugin.py
@@ -294,7 +294,13 @@ class LazyInitStepContext(StepContext):
 
     @property
     def allure(self):
-        return self.allure_helper.get_listener()
+        l = self.allure_helper.get_listener()
+
+        # if listener has `stack` we are inside a test
+        # record steps only when that
+        # FIXME: this breaks encapsulation a lot
+        if hasattr(l, 'stack'):
+            return l
 
 
 class AllureHelper(object):

--- a/tests/test_metafunc.py
+++ b/tests/test_metafunc.py
@@ -1,0 +1,30 @@
+"""
+Test pytest metafunc integrations
+
+Created on Apr 18, 2016
+
+@author: pupssman
+"""
+
+from hamcrest import assert_that, contains, has_property
+
+
+def test_steps_in_parametrize(report_for):
+    """
+    Test that allure steps do not cause problems in pytest_generate_tests
+    """
+    report = report_for('''
+    import allure
+
+    @allure.step
+    def foo():
+        return 'hello'
+
+    def pytest_generate_tests(metafunc):
+        metafunc.parametrize('val', [foo()])
+
+    def test_foo(val):
+        assert val
+    ''')
+
+    assert_that(report.findall('.//test-case'), contains(has_property('name', 'test_foo[hello]')))


### PR DESCRIPTION
I've recently encountered a problem with `allure.step`-wrapped function in `pytest_generate_tests` -- they fail with ugly trace like

``` python
==================================== ERRORS ====================================
 ERROR collecting .tox/py27/tmp/testdir/test_steps_in_parametrize1/test_steps_in_parametrize.py 
test_steps_in_parametrize.py:8: in pytest_generate_tests
    metafunc.parametrize('val', [foo()])
../../../local/lib/python2.7/site-packages/allure/common.py:56: in impl
    with StepContext(self.allure, self.title.format(*a, **kw)):
../../../local/lib/python2.7/site-packages/allure/common.py:34: in __enter__
    self.step = self.allure.start_step(self.title)
../../../local/lib/python2.7/site-packages/allure/pytest_plugin.py:159: in start_step
    self.stack[-1].steps.append(step)
E   AttributeError: 'AllureTestListener' object has no attribute 'stack'
=========================== 1 error in 0.27 seconds ============================
```

That is due to fact that `stack` is initialized per-test and only during `pytest_runtest_protocol` hook invocation. Added test manifest that behaviour.

The fix proposed is super-ugly, but does the trick. I'm considering other options -- but that may serve as an intermediate solution for now.

Proper fix not discard steps information from pre-test-run period but record them and display in the report.
