### PR TITLE
Fix compatibility with latest pytest version (2.9.2)

### DIFF
--- a/allure/pytest_plugin.py
+++ b/allure/pytest_plugin.py
@@ -4,14 +4,13 @@ import pytest
 import argparse
 
 from collections import namedtuple
-from _pytest.junitxml import mangle_testnames
 from six import text_type
 
 from allure.common import AllureImpl, StepContext
 from allure.constants import Status, AttachmentType, Severity, \
     FAILED_STATUSES, Label, SKIPPED_STATUSES
 from allure.utils import parent_module, parent_down_from_module, labels_of, \
-    all_of, get_exception_message, now
+    all_of, get_exception_message, now, mangle_testnames
 from allure.structure import TestCase, TestStep, Attach, TestSuite, Failure, TestLabel
 
 

--- a/allure/utils.py
+++ b/allure/utils.py
@@ -160,3 +160,15 @@ def host_tag():
     Return a special host_tag value, representing current host.
     """
     return socket.gethostname()
+
+
+def mangle_testnames(names):
+    """
+    Return clean test names
+
+    This was backported from pytest v2.9.0.
+
+    :param names: list of test names
+    :returns: list of clean test names
+    """
+    return [n.replace('.py', '') for n in names if n != '()']

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ VERSION = "1.7.5"
 
 install_requires = [
     "lxml>=3.2.0",
-    "pytest>=2.7.3,<=2.9.0",
+    "pytest>=2.7.3",
     "namedlist",
     "six>=1.9.0"
 ]


### PR DESCRIPTION
Hi,

this fixes #92 by backporting the private `_pytest.junitxml.mangle_testnames` function.

Cheers,

Ivan
