### PR TITLE
pytest 3 support added

### DIFF
--- a/allure/pytest_plugin.py
+++ b/allure/pytest_plugin.py
@@ -4,14 +4,13 @@ import pytest
 import argparse
 
 from collections import namedtuple
-from _pytest.junitxml import mangle_testnames
 from six import text_type
 
 from allure.common import AllureImpl, StepContext
 from allure.constants import Status, AttachmentType, Severity, \
     FAILED_STATUSES, Label, SKIPPED_STATUSES
 from allure.utils import parent_module, parent_down_from_module, labels_of, \
-    all_of, get_exception_message, now
+    all_of, get_exception_message, now, mangle_testnames
 from allure.structure import TestCase, TestStep, Attach, TestSuite, Failure, TestLabel
 
 

--- a/allure/utils.py
+++ b/allure/utils.py
@@ -105,12 +105,14 @@ def all_of(enum):
     """
     returns list of name-value pairs for ``enum`` from :py:mod:`allure.constants`
     """
+
     def clear_pairs(pair):
         if pair[0].startswith('_'):
             return False
         if pair[0] in ('name', 'value'):
             return False
         return True
+
     return filter(clear_pairs, inspect.getmembers(enum))
 
 
@@ -160,3 +162,9 @@ def host_tag():
     Return a special host_tag value, representing current host.
     """
     return socket.gethostname()
+
+
+def mangle_testnames(names):
+    names = [x.replace(".py", "") for x in names if x != '()']
+    names[0] = names[0].replace("/", '.')
+    return names

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ VERSION = "1.7.6"
 
 install_requires = [
     "lxml>=3.2.0",
-    "pytest>=2.7.3,<=2.9.0",
+    "pytest>=2.7.3",
     "namedlist",
     "six>=1.9.0"
 ]

--- a/tests/test_traces.py
+++ b/tests/test_traces.py
@@ -82,13 +82,13 @@ def test_xpass(report_for):
     report = report_for("""
     import pytest
 
-    @pytest.mark.xfail(reason='ololo')
+    @pytest.mark.xfail(strict=True, reason='ololo')
     def test_Y():
         assert True
     """)
 
-    assert_that(report, has_error(message='xpassed',
-                                  trace='ololo'))
+    assert_that(report, has_error(message='Failed: [XPASS(strict)] ololo',
+                                  trace='[XPASS(strict)] ololo'))
 
 
 def test_xfail(report_for):


### PR DESCRIPTION
This pull request will fix support for pytest 2 and 3 version. In pytest 3, according to https://github.com/pytest-dev/pytest/commit/28530836c9351c3b18434b9a3dc4fc1f1900a7fb function `mangle_testnames ` was renamed so to be compatible with both version we replaced call of this function inside pytest-adapter by our own function.