### PR TITLE
Feature/optimize

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -278,12 +278,16 @@ More details about allure environment you can know from documentation_.
 
 .. _documentation: https://github.com/allure-framework/allure-core/wiki/Environment
 
+
 Report optimization
 ======================
 To remove steps,attachments or labels from PASSED test cases --allure_optimizereport parammeter can be useed. This is
 usefull in cases when testsuite have a lot of testcases.
+
 .. code:: python
-     py.test ./my-test --alluredir=/path/to/report --allure_optimizereport=attachments,steps,labels
+
+ py.test ./my-test --alluredir=/path/to/report --allure_optimizereport=attachments,steps,labels
+
 
 Development
 ===========

--- a/README.rst
+++ b/README.rst
@@ -278,6 +278,12 @@ More details about allure environment you can know from documentation_.
 
 .. _documentation: https://github.com/allure-framework/allure-core/wiki/Environment
 
+Report optimization
+======================
+To remove steps,attachments or labels from PASSED test cases --allure_optimizereport parammeter can be useed. This is
+usefull in cases when testsuite have a lot of testcases.
+.. code:: python
+     py.test ./my-test --alluredir=/path/to/report --allure_optimizereport=attachments,steps,labels
 
 Development
 ===========

--- a/allure/pytest_plugin.py
+++ b/allure/pytest_plugin.py
@@ -496,7 +496,6 @@ class AllureAgregatingListener(object):
                 refined_tests = []
                 for t in s.tests[::-1]:
                     if t.id not in known_ids:
-                        '''
                         if t.status == 'passed' and self.optimizereport:
                             if 'attachments' in self.optimizereport:
                                 t.attachments = []
@@ -504,7 +503,6 @@ class AllureAgregatingListener(object):
                                 t.steps = []
                             if 'labels' in self.optimizereport:
                                 t.labels = []
-                        '''
                         known_ids.add(t.id)
                         refined_tests.append(t)
                 s.tests = refined_tests[::-1]
@@ -533,9 +531,9 @@ class AllureAgregatingListener(object):
 
             self.impl.environment.update(environment)
 
-            #if testcase.status != 'passed' or 'attachments' not in self.optimizereport:
-            for a in testcase.iter_attachments():
-                self.write_attach(a)
+            if testcase.status != 'passed' or 'attachments' not in self.optimizereport:
+                for a in testcase.iter_attachments():
+                    self.write_attach(a)
 
             self.suites.setdefault(module_id, TestSuite(name=module_name,
                                                         description=module_doc,

--- a/allure/pytest_plugin.py
+++ b/allure/pytest_plugin.py
@@ -496,6 +496,7 @@ class AllureAgregatingListener(object):
                 refined_tests = []
                 for t in s.tests[::-1]:
                     if t.id not in known_ids:
+                        '''
                         if t.status == 'passed' and self.optimizereport:
                             if 'attachments' in self.optimizereport:
                                 t.attachments = []
@@ -503,6 +504,7 @@ class AllureAgregatingListener(object):
                                 t.steps = []
                             if 'labels' in self.optimizereport:
                                 t.labels = []
+                        '''
                         known_ids.add(t.id)
                         refined_tests.append(t)
                 s.tests = refined_tests[::-1]
@@ -531,9 +533,9 @@ class AllureAgregatingListener(object):
 
             self.impl.environment.update(environment)
 
-            if testcase.status != 'passed' or 'attachments' not in self.optimizereport:
-                for a in testcase.iter_attachments():
-                    self.write_attach(a)
+            #if testcase.status != 'passed' or 'attachments' not in self.optimizereport:
+            for a in testcase.iter_attachments():
+                self.write_attach(a)
 
             self.suites.setdefault(module_id, TestSuite(name=module_name,
                                                         description=module_doc,

--- a/allure/pytest_plugin.py
+++ b/allure/pytest_plugin.py
@@ -24,7 +24,8 @@ def pytest_addoption(parser):
 
     parser.getgroup("reporting").addoption('--allure_optimizereport',
                                            dest="optimizereport",
-                                           help="""Removes attachments,steps or labels from test cases. Possible comma separated values: attachments,labels,steps""",
+                                           help="""Removes attachments,steps or labels from PASSED test cases. Possible
+                                           comma separated values: attachments,labels,steps""",
                                            default=None)
 
     severities = [v for (_, v) in all_of(Severity)]

--- a/tests/test_optimizereport.py
+++ b/tests/test_optimizereport.py
@@ -1,0 +1,40 @@
+"""
+Test parameter --allure_optimizereport.
+- test if attachment gets removed from passed testcases
+- test if label gets removed from passed testcases
+- test if steps removed from passed test cases
+
+Created on Aug 30, 2017
+
+@author: hasansna
+"""
+
+
+import pytest
+
+
+from hamcrest import assert_that, is_not, has_property, contains, has_entries, \
+    has_properties, has_item, anything, all_of, any_of,equal_to
+from allure.constants import AttachmentType
+from allure.utils import all_of
+
+import pprint
+
+def test_smoke(report_for):
+
+    extra_run_args = list()
+    extra_run_args.extend(['--allure_stories', 'attachments,steps,labels'])
+
+    report = report_for("""
+    import pytest
+    import allure
+
+    def test_x():
+        %s.attach('Foo', 'Bar')
+    """ % extra_run_args)
+
+    print "Report!!!"
+    pprint.pprint(report)
+
+    assert_that(is_not(report.findall('test-cases/test-case/attachments/attachment'),
+                contains(has_property('attrib', has_entries(title='Foo')))))

--- a/tests/test_optimizereport.py
+++ b/tests/test_optimizereport.py
@@ -12,29 +12,33 @@ Created on Aug 30, 2017
 
 import pytest
 
-
-from hamcrest import assert_that, is_not, has_property, contains, has_entries, \
-    has_properties, has_item, anything, all_of, any_of,equal_to
-from allure.constants import AttachmentType
-from allure.utils import all_of
-
-import pprint
+def xml_test(report):
+    if report.find('.//attachment') != None:
+        print "attachment found in report"
+        assert False
+    if report.find('.//label') != None:
+        print "Label found in report"
+        assert False
+    if report.find('.//step') != None:
+        print "step found in report"
+        assert False
 
 def test_smoke(report_for):
 
     extra_run_args = list()
-    extra_run_args.extend(['--allure_stories', 'attachments,steps,labels'])
+
+    extra_run_args.extend(['--allure_optimizereport', 'attachments,steps,labels'])
 
     report = report_for("""
     import pytest
     import allure
 
-    def test_x():
-        %s.attach('Foo', 'Bar')
-    """ % extra_run_args)
+    def test():
+        with pytest.allure.step(title='step_1'):
+            assert True
+        pytest.allure.attach('Foo', 'Bar')
+    """ , extra_run_args=extra_run_args)
 
-    print "Report!!!"
-    pprint.pprint(report)
+    xml_test(report)
 
-    assert_that(is_not(report.findall('test-cases/test-case/attachments/attachment'),
-                contains(has_property('attrib', has_entries(title='Foo')))))
+

--- a/tests/test_optimizereport.py
+++ b/tests/test_optimizereport.py
@@ -14,13 +14,13 @@ import pytest
 
 def xml_test(report):
     if report.find('.//attachment') != None:
-        print "attachment found in report"
+        print ("attachment found in report")
         assert False
     if report.find('.//label') != None:
-        print "Label found in report"
+        print ("attachment found in report")
         assert False
     if report.find('.//step') != None:
-        print "step found in report"
+        print ("attachment found in report")
         assert False
 
 def test_smoke(report_for):


### PR DESCRIPTION
In cases when we generates a lot of testcases per suite a lot of files then are generated in allure html report. 
--
In cases when we generates a lot of testcases per suite a lot of files then are generated in allure html report. A lot of files takes a lot of inodes in server file system, report generation takes more time and resources.
By removing attachments,labels and steps from allure report tests reports became ~1/3  lighter. 
Created new parameter --allure_optimizereport using that it is possible to define what to remove

