### PR TITLE
small fix to make context wrapper return itself to caller

### DIFF
--- a/allure/common.py
+++ b/allure/common.py
@@ -35,6 +35,7 @@ class StepContext:
     def __enter__(self):
         if self.allure:
             self.step = self.allure.start_step(self.title)
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.allure:

--- a/allure/pytest_plugin.py
+++ b/allure/pytest_plugin.py
@@ -295,13 +295,13 @@ class LazyInitStepContext(StepContext):
 
     @property
     def allure(self):
-        l = self.allure_helper.get_listener()
+        listener = self.allure_helper.get_listener()
 
         # if listener has `stack` we are inside a test
         # record steps only when that
         # FIXME: this breaks encapsulation a lot
-        if hasattr(l, 'stack'):
-            return l
+        if hasattr(listener, 'stack'):
+            return listener
 
 
 class AllureHelper(object):


### PR DESCRIPTION
that allows following use:

```
def test_what()
   with allure.step('Check something') as step:
        # use step.title for e.g. logging or as a prefix for a sequence of screenshots made during this step
        assert step.title == 'Check something'
```