### PR TITLE
Added ability to set test's description inside test function

### DIFF
--- a/allure/__init__.py
+++ b/allure/__init__.py
@@ -12,6 +12,7 @@ __methods_to_provide = [
     'severity',
     'issue',
     'dynamic_issue',
+    'description',
     'testcase',
     'environment',
     'attach_type',

--- a/allure/pytest_plugin.py
+++ b/allure/pytest_plugin.py
@@ -145,6 +145,13 @@ class AllureTestListener(object):
         if self.test:
             self.test.labels.extend([TestLabel(name=Label.ISSUE, value=issue) for issue in issues])
 
+    def description(self, description):
+        """
+        Sets description for the test
+        """
+        if self.test:
+            self.test.description = description
+
     def start_step(self, name):
         """
         Starts an new :py:class:`allure.structure.TestStep` with given ``name``,
@@ -361,6 +368,13 @@ class AllureHelper(object):
         """
         if self._allurelistener:
             self._allurelistener.dynamic_issue(*issues)
+
+    def description(self, description):
+        """
+        Sets description for the test
+        """
+        if self._allurelistener:
+            self._allurelistener.description(description)
 
     def testcase(self, *testcases):
         """

--- a/allure/pytest_plugin.py
+++ b/allure/pytest_plugin.py
@@ -308,7 +308,7 @@ class LazyInitStepContext(StepContext):
         # record steps only when that
         # FIXME: this breaks encapsulation a lot
         if hasattr(listener, 'stack'):
-            return listeners
+            return listener
 
 
 class AllureHelper(object):

--- a/allure/pytest_plugin.py
+++ b/allure/pytest_plugin.py
@@ -302,13 +302,13 @@ class LazyInitStepContext(StepContext):
 
     @property
     def allure(self):
-        l = self.allure_helper.get_listener()
+        listener = self.allure_helper.get_listener()
 
         # if listener has `stack` we are inside a test
         # record steps only when that
         # FIXME: this breaks encapsulation a lot
-        if hasattr(l, 'stack'):
-            return l
+        if hasattr(listener, 'stack'):
+            return listeners
 
 
 class AllureHelper(object):

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -10,8 +10,8 @@ def test_descriptions(report_for, package):
     import allure
 
     def test_x():
-        %s.description('Foo')
+        %s.description('Description')
     """ % package)
 
     assert_that(report.findall('.//test-case'),
-                contains(has_property('description', equal_to('Foo'))))
+                contains(has_property('description', equal_to('Description'))))

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -1,17 +1,17 @@
 import pytest
 
-from hamcrest import assert_that, contains, all_of, has_entry, has_property, has_properties
+from hamcrest import assert_that, contains, has_property, equal_to
 
 
 @pytest.mark.parametrize('package', ['pytest.allure', 'allure'])
-def test_doctests(report_for, package):
+def test_descriptions(report_for, package):
     report = report_for("""
     import pytest
     import allure
 
-    def hello_world():
-        %s.description('hello world')
+    def test_x():
+        %s.description('Foo')
     """ % package)
 
-    assert_that(report.findall('.//test-case'), contains(
-        has_property('description', 'test_doctests.hello_world')))
+    assert_that(report.findall('.//test-case'),
+                contains(has_property('description', equal_to('Foo'))))

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -1,0 +1,17 @@
+import pytest
+
+from hamcrest import assert_that, contains, all_of, has_entry, has_property, has_properties
+
+
+@pytest.mark.parametrize('package', ['pytest.allure', 'allure'])
+def test_doctests(report_for, package):
+    report = report_for("""
+    import pytest
+    import allure
+
+    def hello_world():
+        %s.description('hello world')
+    """ % package)
+
+    assert_that(report.findall('.//test-case'), contains(
+        has_property('description', 'test_doctests.hello_world')))


### PR DESCRIPTION
In case if docstring is not enough for test's description this change will give an ability to set it from the test function in the following way: pytest.allure.description("Some description"))